### PR TITLE
Discord Open Source logo

### DIFF
--- a/logo/discord-open-source/cdnjs.svg
+++ b/logo/discord-open-source/cdnjs.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="72px" height="72px" viewBox="0 0 72 72" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 53.2 (72643) - https://sketchapp.com -->
+    <title>fav</title>
+    <desc>Created with Sketch.</desc>
+    <g id="fav" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round">
+        <path d="M25.92,17.82 L6.41192942,35.1436437 C5.58537251,35.8776464 5.51034254,37.14273 6.24434528,37.9692869 C6.30883822,38.0419121 6.37853195,38.1097465 6.45287407,38.1722526 L25.92,54.54" id="Path" stroke="#FFFFFF" stroke-width="6.435" fill-rule="nonzero"></path>
+        <path d="M67.32,17.82 L47.8119294,35.1436437 C46.9853725,35.8776464 46.9103425,37.14273 47.6443453,37.9692869 C47.7088382,38.0419121 47.778532,38.1097465 47.8528741,38.1722526 L67.32,54.54" id="Path" stroke="#FFFFFF" stroke-width="6.435" fill-rule="nonzero" transform="translate(56.700000, 36.180000) scale(-1, 1) translate(-56.700000, -36.180000) "></path>
+    </g>
+</svg>


### PR DESCRIPTION
Add the SVG favicon logo, monochrome, that will be used on the [Discord Open Source page](https://discordapp.com/open-source).