### PR TITLE
Add palette ref/readme

### DIFF
--- a/palette/README.md
+++ b/palette/README.md
@@ -1,0 +1,10 @@
+# cdnjs Palette
+
+| Preview | Hex Code | Usage |
+|---------|----------|-------|
+|<img src="https://github.com/cdnjs/brand/blob/master/palette/primary-D9643A.png?raw=true" width="64" alt=""/>|#D9643A|Primary|
+|<img src="https://github.com/cdnjs/brand/blob/master/palette/secondary-E95420.png?raw=true" width="64" alt=""/>|#E95420|Secondary|
+|<img src="https://github.com/cdnjs/brand/blob/master/palette/dark-454647.png?raw=true" width="64" alt=""/>|#454647|Dark|
+|<img src="https://github.com/cdnjs/brand/blob/master/palette/light-EBEBEB.png?raw=true" width="64" alt=""/>|#EBEBEB|Light|
+|<img src="https://github.com/cdnjs/brand/blob/master/palette/alt-A6A6A6.png?raw=true" width="64" alt=""/>|#A6A6A6|Alt|
+|<img src="https://github.com/cdnjs/brand/blob/master/palette/notice-1EADAE.png?raw=true" width="64" alt=""/>|#1EADAE|Notices|


### PR DESCRIPTION
Add a simple reference table as the readme file for the palette directory, containing the cdnjs brand colors.