### PR TITLE
Fix broken links in various README files

### DIFF
--- a/logo/README.md
+++ b/logo/README.md
@@ -6,7 +6,7 @@
 
 ---
 
-[Back to parent directory](..)
+[Back to parent directory](https://github.com/cdnjs/brand)
 
 ## Logo types
 

--- a/palette/README.md
+++ b/palette/README.md
@@ -6,7 +6,7 @@
 
 ---
 
-[Back to parent directory](..)
+[Back to parent directory](https://github.com/cdnjs/brand)
 
 ## Color Palette
 

--- a/website/README.md
+++ b/website/README.md
@@ -6,7 +6,7 @@
 
 ---
 
-[Back to parent directory](..)
+[Back to parent directory](https://github.com/cdnjs/brand)
 
 ## Website Design
 


### PR DESCRIPTION
the different readmes located in [`logo/`](https://github.com/cdnjs/brand/tree/master/logo), [`palette/`](https://github.com/cdnjs/brand/tree/master/palette) and [`website/`](https://github.com/cdnjs/brand/tree/master/logo) all use `..` as link for the "Back to parent directory" which GitHub doesn't like and results in a 404 Page not found error.

This PR changes the links to absolute ones which just point to this Repository (https://github.com/cdnjs/brand/tree/master/logo).
If this isn't wanted (i.e. because this is used online somewhere) let me know and I'll try to find a different solution such as `/../..` which I avoided because it may not work reliably when looking at the readme directly and not just from a folder (didn't test this tho)